### PR TITLE
remove semicolon to make the linter fail

### DIFF
--- a/starter-code/wat.js
+++ b/starter-code/wat.js
@@ -1,1 +1,1 @@
-var yup = 'hello';
+var yup = 'hello'


### PR DESCRIPTION
Today I worked on forking, cloning, creating directories and pull requests in Git Hub. 

It was a short review of what we did in 201.
#### Checklist (before submitting, fill in each set of square brackets with an 'x')
- [x] I have entered the Pull Request title in the format of "firstname-lastname"
- [x] This PR includes commits from both myself and my partner; e.g. We followed good pair programming practices by switching driver/navigator roles.
- [x] There is no extraneous, unrelated code included in this PR.
- [x] We have summarized our `TODO:` process above.
